### PR TITLE
Custom replace config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,39 @@ async function myFunction() {
 | `--importMap <path to file>` | Path to a file containing an import map in valid JSON format. Uses [this rollup-plugin](https://www.npmjs.com/package/@eik/rollup-plugin) to translate imports to use specified URLs instead (see example). Takes precedence over `--includeDependencies` for imports included in the import map. | optional | | `{ "react": "https://<my-cool-cdn>/react.esm.js" }` |
 | `--outputFile <path to file>` | Where to output the finished bundle | optional | `./index.js` | |
 
+### Replacing strings in output build
+
+If you want to modify the output of the rollup build before writing the contents to a file, the [rollup-build](https://github.com/navikt/npm-to-esm/blob/main/utils/make-esm-bundle.js) has been configured with usage of [rollup's replace plugin](https://www.npmjs.com/package/@rollup/plugin-replace), and providing a custom config object to this plugin is supported when using npm-to-esm from Node.js (please read the docs for @rollup/plugin-replace for how to configure it for your use case).
+
+Example:
+```
+const npmToEsm = require('@navikt/npm-to-esm');
+
+async function myFunction() {
+    const rollupOutput = await npmToEsm({ 
+        packageName: '@navikt/ds-react', 
+        packageVersion: '0.16.8'
+        replaceConfig: {
+            delimiters: ['', ''],
+            values: {
+                'process.env.NODE_ENV': JSON.stringify('production'),
+                'import { myNamedExport }': 'import myDefaultExport' 
+            }
+        }
+    })
+}
+```
+
+**Please note: The replace plugin does have a default configuration set up in the rollup build, regardless of whether npm-to-esm is being used from Node.js or CLI.**
+
+Currently, it is configured with this by default:
+```
+{
+    preventAssignment: true,
+    'process.env.NODE_ENV': JSON.stringify('production'),
+};
+```
+
 ---
 
 # Contact

--- a/npm-to-esm.js
+++ b/npm-to-esm.js
@@ -6,5 +6,5 @@ module.exports = async (options) => {
     const optionsArray = optionsObjectToArray(options);
     const validatedOptions = await validateArguments(optionsArray, false);
     validatedOptions.importMap = validatedOptions.importMap ?? options.importMap;
-    return await runNpmToEsm(validatedOptions);
+    return await runNpmToEsm(validatedOptions, options.replaceConfig);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/npm-to-esm",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "bin": {
     "npm-to-esm": "./bin/index.js"
   },

--- a/utils/run-npm-to-esm.js
+++ b/utils/run-npm-to-esm.js
@@ -1,8 +1,8 @@
 const prepareNpmPackage = require('./prepare-npm-package');
 const makeEsmBundle = require('./make-esm-bundle');
 
-module.exports = async function runNpmToEsm(options) {
+module.exports = async function runNpmToEsm(options, replaceConfig) {
     const { packageName, packageVersion, entry, includeDependencies, outputFile, importMap } = options;
     const { inputPath, directory } = await prepareNpmPackage(packageName, packageVersion, entry, includeDependencies);
-    return await makeEsmBundle(inputPath, outputFile, directory, importMap);
+    return await makeEsmBundle(inputPath, outputFile, directory, importMap, replaceConfig);
 };


### PR DESCRIPTION
Add support in Node.js for providing a custom config to the usage of rollup's replace plugin.
Remove unneccessary rollup.generate call
Update docs